### PR TITLE
updated API example to remove init()

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ API Example
 Main class is `Provider`. To get provider for current platform:
 
     Provider provider = Provider.getCurrentProvider(useSwingEventQueue);
-    provider.init();
     
 where `useSwingEventQueue` is a boolean parameter specifying whether to fire events
 on swing event queue or just simple thread. Usefull when your hotkey listener will 


### PR DESCRIPTION
it seems that the init method is being called in the getCurrentProvider and cannot be called from public. (set to protected).