### PR TITLE
Allow to unregister hotkeys

### DIFF
--- a/core/src/main/java/com/tulskiy/keymaster/common/HotKey.java
+++ b/core/src/main/java/com/tulskiy/keymaster/common/HotKey.java
@@ -44,6 +44,17 @@ public class HotKey {
         return mediaKey != null;
     }
 
+    public boolean isUnregister() {
+        return listener == null;
+    }
+
+    public boolean hasSameTrigger(HotKey other) {
+        if (keyStroke != null) {
+            return other.keyStroke != null && keyStroke.equals(other.keyStroke);
+        }
+        return mediaKey == other.mediaKey;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();

--- a/core/src/main/java/com/tulskiy/keymaster/common/Provider.java
+++ b/core/src/main/java/com/tulskiy/keymaster/common/Provider.java
@@ -130,6 +130,29 @@ public abstract class Provider implements Closeable {
     public abstract void register(MediaKey mediaKey, HotKeyListener listener);
 
     /**
+     * Unregister a global hotkey. Only keyCode and modifiers fields are respected
+     *
+     * @param keyCode  KeyStroke to unregister
+     * @see KeyStroke
+     */
+    public abstract void unregister(KeyStroke keyCode);
+
+    /**
+     * Unregister a media hotkey. Currently supported media keys are:
+     * <br>
+     * <ul>
+     * <li>Play/Pause</li>
+     * <li>Stop</li>
+     * <li>Next track</li>
+     * <li>Previous Track</li>
+     * </ul>
+     *
+     * @param mediaKey media key to unregister
+     * @see MediaKey
+     */
+    public abstract void unregister(MediaKey mediaKey);
+
+    /**
      * Helper method fro providers to fire hotkey event in a separate thread
      *
      * @param hotKey hotkey to fire

--- a/dbus/pom.xml
+++ b/dbus/pom.xml
@@ -49,9 +49,9 @@
             <version>${parent.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.freedesktop.dbus</groupId>
+            <groupId>com.github.hypfvieh</groupId>
             <artifactId>dbus-java</artifactId>
-            <version>2.7</version>
+            <version>2.7.5</version>
         </dependency>
     </dependencies>
 </project>

--- a/dbus/src/main/java/com/tulskiy/keymaster/dbus/GnomeMediaProvider.java
+++ b/dbus/src/main/java/com/tulskiy/keymaster/dbus/GnomeMediaProvider.java
@@ -71,6 +71,16 @@ public class GnomeMediaProvider extends Provider {
         listeners.put(mediaKey, listener);
     }
 
+    @Override
+    public void unregister(KeyStroke keyCode) {
+        throw new UnsupportedOperationException("only media keys are supported");
+    }
+
+    @Override
+    public void unregister(MediaKey mediaKey) {
+        listeners.remove(mediaKey);
+    }
+
     private void fire(MediaKey key) {
         HotKeyListener listener = listeners.get(key);
         if (listener != null) {

--- a/pom.xml
+++ b/pom.xml
@@ -115,8 +115,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This pull request adds an `unregister()` method to ´Provider´, so that hotkeys can be unregistered again. The unregister functionality is implemented for all platforms, but I only tested it on Windows.

In addition I made two unrelated changes:
- Changed the `dbus-java` dependency, previously provided by `org.freedesktop.dbus` to this actively developed [fork](https://github.com/hypfvieh/dbus-java), as the original project  is no longer maintained and no longer available in maven central.
- Increased the Java target version to 1.8, to be able to use the [`Collection.removeIf()`](https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html#removeIf-java.util.function.Predicate-) method.

In case you don't approve that additional changes or prefer to have them in a separate pull request, I am willing to adapt my code respectively the pull request accordingly.
