### PR TITLE
Various provider changes

### DIFF
--- a/core/src/main/java/com/tulskiy/keymaster/common/Provider.java
+++ b/core/src/main/java/com/tulskiy/keymaster/common/Provider.java
@@ -103,6 +103,17 @@ public abstract class Provider implements Closeable {
         reset();
         stop();
     }
+    
+    /**
+     * Determines whether the provider thread is still running. If the thread
+     * isn't running it may have been intentionally stopped via stop() or an
+     * unhandled error may have occured. If the thread isn't running this
+     * instance can't be used anymore. If the thread is running, it can probably
+     * still be used, however it might also just be about to stop.
+     * 
+     * @return
+     */
+    public abstract boolean isRunning();
 
     /**
      * Register a global hotkey. Only keyCode and modifiers fields are respected

--- a/core/src/main/java/com/tulskiy/keymaster/windows/KeyMap.java
+++ b/core/src/main/java/com/tulskiy/keymaster/windows/KeyMap.java
@@ -27,6 +27,18 @@ import static java.awt.event.KeyEvent.VK_PLUS;
 import static java.awt.event.KeyEvent.VK_PRINTSCREEN;
 import static java.awt.event.KeyEvent.VK_SEMICOLON;
 import static java.awt.event.KeyEvent.VK_SLASH;
+import static java.awt.event.KeyEvent.VK_F13;
+import static java.awt.event.KeyEvent.VK_F14;
+import static java.awt.event.KeyEvent.VK_F15;
+import static java.awt.event.KeyEvent.VK_F16;
+import static java.awt.event.KeyEvent.VK_F17;
+import static java.awt.event.KeyEvent.VK_F18;
+import static java.awt.event.KeyEvent.VK_F19;
+import static java.awt.event.KeyEvent.VK_F20;
+import static java.awt.event.KeyEvent.VK_F21;
+import static java.awt.event.KeyEvent.VK_F22;
+import static java.awt.event.KeyEvent.VK_F23;
+import static java.awt.event.KeyEvent.VK_F24;
 
 import com.sun.jna.platform.win32.Win32VK;
 import com.sun.jna.platform.win32.WinUser;
@@ -54,6 +66,18 @@ class KeyMap {
         put(VK_SLASH, 0xBF);
         put(VK_SEMICOLON, 0xBA);
         put(VK_PRINTSCREEN, 0x2C);
+        put(VK_F13, 0x7C);
+        put(VK_F14, 0x7D);
+        put(VK_F15, 0x7E);
+        put(VK_F16, 0x7F);
+        put(VK_F17, 0x80);
+        put(VK_F18, 0x81);
+        put(VK_F19, 0x82);
+        put(VK_F20, 0x83);
+        put(VK_F21, 0x84);
+        put(VK_F22, 0x85);
+        put(VK_F23, 0x86);
+        put(VK_F24, 0x87);
     }};
 
     static int getCode(HotKey hotKey) {

--- a/core/src/main/java/com/tulskiy/keymaster/windows/WindowsProvider.java
+++ b/core/src/main/java/com/tulskiy/keymaster/windows/WindowsProvider.java
@@ -17,6 +17,7 @@
 
 package com.tulskiy.keymaster.windows;
 
+import com.sun.jna.platform.win32.Kernel32;
 import com.sun.jna.platform.win32.User32;
 import com.sun.jna.platform.win32.WinUser;
 import com.tulskiy.keymaster.common.HotKey;
@@ -40,42 +41,52 @@ public class WindowsProvider extends Provider {
     private static final Logger LOGGER = LoggerFactory.getLogger(WindowsProvider.class);
     private static volatile int idSeq = 0;
 
-    private boolean listen;
-    private Boolean reset = false;
+    private volatile boolean listen = true;
+    private volatile boolean reset = false;
     private final Object lock = new Object();
     private Thread thread;
+    private int threadId;
 
-    private Map<Integer, HotKey> hotKeys = new HashMap<Integer, HotKey>();
-    private Queue<HotKey> registerQueue = new LinkedList<HotKey>();
+    private final Map<Integer, HotKey> hotKeys = new HashMap<>();
+    private final Queue<HotKey> registerQueue = new LinkedList<>();
 
+    @Override
     public void init() {
         Runnable runnable = new Runnable() {
             public void run() {
                 LOGGER.info("Starting Windows global hotkey provider");
                 WinUser.MSG msg = new WinUser.MSG();
-                listen = true;
-                while (listen) {
-                    while (User32.INSTANCE.PeekMessage(msg, null, 0, 0, 1)) {
-                        if (msg.message == WinUser.WM_HOTKEY) {
-                            int id = msg.wParam.intValue();
-                            HotKey hotKey = hotKeys.get(id);
+                synchronized (lock) {
+                    threadId = Kernel32.INSTANCE.GetCurrentThreadId();
+                    // Run once in this thread to start message queue
+                    // (also causes it to go through the loop once)
+                    unblock();
+                }
+                while (listen || reset) {
+                    if (listen) {
+                        int result = User32.INSTANCE.GetMessage(msg, null, 0, 0);
+                        if (result == -1) {
+                            LOGGER.warn("Error getting message: "+Kernel32.INSTANCE.GetLastError());
+                            listen = false;
+                        } else {
+                            if (msg.message == WinUser.WM_HOTKEY) {
+                                int id = msg.wParam.intValue();
+                                HotKey hotKey = hotKeys.get(id);
 
-                            if (hotKey != null) {
-                                fireEvent(hotKey);
+                                if (hotKey != null) {
+                                    fireEvent(hotKey);
+                                }
                             }
                         }
                     }
-
                     synchronized (lock) {
                         if (reset) {
                             LOGGER.info("Reset hotkeys");
                             for (Integer id : hotKeys.keySet()) {
                                 User32.INSTANCE.UnregisterHotKey(null, id);
                             }
-
                             hotKeys.clear();
                             reset = false;
-                            lock.notify();
                         }
 
                         while (!registerQueue.isEmpty()) {
@@ -86,18 +97,17 @@ public class WindowsProvider extends Provider {
                                 register(hotKey);
                             }
                         }
-                        try {
-                            lock.wait(300);
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        }
                     }
                 }
-                LOGGER.info("Exit listening thread");
+                LOGGER.info("Exit Windows global hotkey thread");
+                // Shouldn't try to send messages to this thread anymore
+                synchronized (lock) {
+                    threadId = 0;
+                }
             }
         };
 
-        thread = new Thread(runnable);
+        thread = new Thread(runnable, "JKeyMaster-Windows");
         thread.start();
     }
 
@@ -105,22 +115,27 @@ public class WindowsProvider extends Provider {
         int id = idSeq++;
         int code = KeyMap.getCode(hotKey);
         if (User32.INSTANCE.RegisterHotKey(null, id, KeyMap.getModifiers(hotKey.keyStroke), code)) {
-            LOGGER.info("Registering hotkey: " + hotKey);
+            LOGGER.info(String.format("Registered hotkey: %s (%2$d/0x%2$X) [%3$d]",
+                    hotKey, code, id));
             hotKeys.put(id, hotKey);
         } else {
             LOGGER.warn("Could not register hotkey: " + hotKey);
         }
     }
 
+    @Override
     public void register(KeyStroke keyCode, HotKeyListener listener) {
         synchronized (lock) {
             registerQueue.add(new HotKey(keyCode, listener));
+            unblock();
         }
     }
-
+    
+    @Override
     public void register(MediaKey mediaKey, HotKeyListener listener) {
         synchronized (lock) {
             registerQueue.add(new HotKey(mediaKey, listener));
+            unblock();
         }
     }
 
@@ -128,7 +143,9 @@ public class WindowsProvider extends Provider {
         hotKeys.entrySet().removeIf(regHotKey -> {
             boolean matches = hotKey.hasSameTrigger(regHotKey.getValue());
             if (matches) {
-                if (!User32.INSTANCE.UnregisterHotKey(null, regHotKey.getKey())) {
+                if (User32.INSTANCE.UnregisterHotKey(null, regHotKey.getKey())) {
+                    LOGGER.info("Unregistered hotkey: " + hotKey);
+                } else {
                     LOGGER.warn("Could not unregister hotkey: " + hotKey);
                 }
             }
@@ -136,33 +153,40 @@ public class WindowsProvider extends Provider {
         });
     }
 
+    @Override
     public void unregister(KeyStroke keyCode) {
         synchronized (lock) {
             registerQueue.add(new HotKey(keyCode, null));
+            unblock();
         }
     }
 
+    @Override
     public void unregister(MediaKey mediaKey) {
         synchronized (lock) {
             registerQueue.add(new HotKey(mediaKey, null));
+            unblock();
         }
     }
 
+    @Override
     public void reset() {
-        synchronized (lock) {
-            reset = true;
-            try {
-                lock.wait();
-            } catch (InterruptedException e) {
-                e.printStackTrace();
+        if (isRunning()) {
+            synchronized (lock) {
+                reset = true;
+                registerQueue.clear();
+                unblock();
             }
         }
     }
 
     @Override
     public void stop() {
-        listen = false;
-        if (thread != null) {
+        if (isRunning()) {
+            synchronized (lock) {
+                listen = false;
+                unblock();
+            }
             try {
                 thread.join();
             } catch (InterruptedException e) {
@@ -171,4 +195,21 @@ public class WindowsProvider extends Provider {
         }
         super.stop();
     }
+    
+    @Override
+    public boolean isRunning() {
+        return thread != null && thread.isAlive();
+    }
+    
+    /**
+     * Send a message to unblock the GetMessage() call for one loop.
+     */
+    private void unblock() {
+        if (threadId != 0) {
+            if (User32.INSTANCE.PostThreadMessage(threadId, WinUser.WM_USER + 1, null, null) == 0) {
+                LOGGER.warn("Posting unblock message failed (thread " + threadId + "): " + Kernel32.INSTANCE.GetLastError());
+            }
+        }
+    }
+    
 }


### PR DESCRIPTION
Thanks for creating this library, it's quite helpful. I've experimented with it a bit and implemented some changes for my own use which might also be interesting for others. Let me know if you want me to split up specific changes into their own PR.

I mainly use Windows, so I mostly tested and worked on the Windows provider, although I tested the changes a bit on Ubuntu and asked others to test on Mac for me.

## General Changes

1. Add `isRunning()` method to tell if the Provider is still active. This is used internally, but also as a public method in order for users of the library to e.g. determine if it still makes sense to try and use the instance.
2. Don't set `listen = true` just before the loop, set it as initial value instead. Reason: If `stop()` is called immediately after starting the provider, the provider thread may not have gotten to the loop yet, which means `listen = true` will be set after `stop()` and `stop()` will wait for the thread to end forever. Probably a bit unlikely that `stop()` would be called immediately, but it still shouldn't cause issues.
3. Name the provider threads, so it's easier to identify them when debugging.
4. Some more information logged.
5. Clear `registerQueue` in `reset()`, otherwise something like `register() -> reset()` called immediately one after the other could leave the hotkey registered. When `reset()` is called, all previous calls to `register()` should have no effect anymore.
6. Don't wait in `reset()`. I assume it's supposed to wait for the reset before ending the thread (e.g. for `close()`). The reset is now ensured by entering the loop also when `reset` is `true`, but preventing getting stuck in `lock.wait()` when the thread is supposed to be stopped. I don't know if unregistering the hotkeys is actually necessary when ending the thread, or if the platform would do that automatically (it sometimes seemed like it), but better safe than sorry I guess.
7. Consistently check `isRunning()` in `reset()` and `stop()`. In some cases calling those at the wrong time caused errors or getting stuck (although probably less now with the other changes).

## Windows Changes

8. Add the correct keycodes for F13-F24 on Windows. These normally unused keycodes can be very useful when bound to additional keys on a programmable keyboard or a second keyboard used for hotkeys.
9. Change `PeekMessage` to `GetMessage`, so the thread doesn't have to keep checking messages on a delay, but instead gets notified immediately. Of course `GetMessage` blocks the thread, so `unblock()` can be called when the thread is needed otherwise (registering hotkey etc.) which sends a message to the thread for the sole purpose of unblocking it for one loop. The `threadId` that the message is sent to was previously retrieved via `GetCurrentThreadId`.

I've numbered the changes so they can be addressed directly. Any thoughts?