### PR TITLE
Fix MOD_NOREPEAT Windows version comparison

### DIFF
--- a/core/src/main/java/com/tulskiy/keymaster/windows/KeyMap.java
+++ b/core/src/main/java/com/tulskiy/keymaster/windows/KeyMap.java
@@ -103,8 +103,17 @@ class KeyMap {
         }
 
         String os = System.getProperty("os.version", "");
+
         // MOD_NOREPEAT only supported starting with Windows 7
-        if (os.compareTo("6.1") >= 0) {
+        boolean modNorepeatSupported;
+        try {
+            modNorepeatSupported = Double.parseDouble(os) >= 6.1;
+        } catch(NumberFormatException e) {
+            // Fallback to a String comparison
+            modNorepeatSupported = os.compareTo("6.1") >= 0;
+        }
+
+        if (modNorepeatSupported) {
             modifiers |= WinUser.MOD_NOREPEAT;
         }
 


### PR DESCRIPTION
Currently the Windows version is compared lexicographically, which means Windows 10 is being interpreted as coming before 6.1.

```
jshell> System.getProperty("os.version", "")
$1 ==> "10.0"

jshell> System.getProperty("os.version", "").compareTo("6.1")
$2 ==> -5
```

The fix I have is naive and assumes Windows won't change their version scheme into a multipart string. It works for now, but the more robust solution would be to make a proper version comparator. I didn't want to add a dependency just for this check though.